### PR TITLE
Change of Alfrid and Charon frontend.

### DIFF
--- a/docs/snippets/frontend-table-1.md
+++ b/docs/snippets/frontend-table-1.md
@@ -2,16 +2,15 @@
 | Frontend address        | Aliased as             | Native home            | OS         | Physically located in    | Note | 
 |-------------------------|------------------------|------------------------|------------|-----------|-----|
 | zenith.cerit-sc.cz   	  | zenith.metacentrum.cz  | /storage/brno12-cerit  | Debian 12  | Brno      |      |
-| nympha.meta.zcu.cz 	  | nympha.metacentrum.cz,<br/> nympha.zcu.cz,<br/> minos.zcu.cz,<br/> minos.meta.zcu.cz | /storage/plzen1        | Debian 12  | Plzen     | |
+| nympha.meta.zcu.cz 	  | nympha.metacentrum.cz,<br/> nympha.zcu.cz,<br/> minos.zcu.cz,<br/> minos.meta.zcu.cz,<br/> alfrid.meta.zcu.cz | /storage/plzen1        | Debian 12  | Plzen     | |
 | skirit.ics.muni.cz 	  | skirit.metacentrum.cz  | /storage/brno2	    | Debian 11  | Brno      | |
-| alfrid.meta.zcu.cz 	  | alfrid.metacentrum.cz  | /storage/plzen1        | Debian 11  | Plzen     | |
 | tarkil.grid.cesnet.cz   | tarkil.metacentrum.cz  | /storage/praha1        | Debian 12  | Praha     | |
 | perian.grid.cesnet.cz   | perian.metacentrum.cz,<br/>onyx.metacentrum.cz | /storage/brno2         | Debian 12  | Brno	     | |
-| charon.nti.tul.cz 	  | charon.metacentrum.cz  | /storage/liberec3-tul  | Debian 11  | Liberec   |  |
+| charon.nti.tul.cz 	  | charon.metacentrum.cz  | /storage/liberec3-tul  | Debian 12  | Liberec   |  |
 | tilia.ibot.cas.cz       | tilia.metacentrum.cz   | /storage/pruhonice1-ibot | Debian 12 | Pruhonice | |
 | zuphux.cerit-sc.cz 	  | zuphux.metacentrum.cz  | /storage/brno12-cerit  | CentOS 7.9 | Brno	     |  |
 | elmo.elixir-czech.cz 	  | elmo.metacentrum.cz    | /storage/praha5-elixir | Debian 11  | Praha     |  |
-| oven.ics.muni.cz     	  | oven.metacentrum.cz    | /storage/brno2         | Debian 11  | Brno      | Reserved to access [oven node](../../computing/node-properties/#oven-node) only |
+| oven.ics.muni.cz     	  | oven.metacentrum.cz    | /storage/brno2         | Debian 12  | Brno      | Reserved to access [oven node](../../computing/node-properties/#oven-node) only |
 | luna.fzu.cz          	  | luna.metacentrum.cz    | /storage/praha1        | Debian 11  | Praha     | Reserved for [FZU](https://www.fzu.cz/en) users |
 
 


### PR DESCRIPTION
The Alfrid frontend has been discontinued and instead there is a CNAME pointing to the Nympha frontend, while the Charon and Oven frontends are now on Debian12.