### PR TITLE
Add link to documentation site in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MetaCentrum User Documentation
 
-This repository contains MetaCentrum grid services user documentation.
+This repository contains MetaCentrum grid services [user documentation](https://docs.metacentrum.cz).
 
 The page is under construction.


### PR DESCRIPTION
Just adding a link to the documentation site so someone doesn't have to type it into the browser.