### PR TITLE
Update filesender.mdx, instruct user to generate an API key

### DIFF
--- a/content/docs/data/filesender.mdx
+++ b/content/docs/data/filesender.mdx
@@ -24,7 +24,7 @@ There is a small bug causing that the GUI does not display entry for users with 
 
 **Download configuration file from Cesnet Filesender**
 
-On main page, choose My Profile --> click on the link Download Python CLI client configuration.
+On main page, choose My Profile --> click on `Create API secret` if you don't have secret key (the long hexadecimal string in previous text field) generated yet and then on the link `Download Python CLI client configuration`.
 
 ![Filesender](/img/meta/data/filesender_1.png)
 


### PR DESCRIPTION
Use may not have an API key already generated, should do it before downloading configuration file preferably.