### PR TITLE
update galaxy index

### DIFF
--- a/content/docs/related/galaxy/index.mdx
+++ b/content/docs/related/galaxy/index.mdx
@@ -3,19 +3,13 @@ title: Galaxy
 ---
 [Galaxy](https://galaxyproject.org/) is a web-based platform designed for running computational and statistical analyses with focus on openness and usage of FAIR data. It originally started in biomedical science but nowadays spans numerous scientific domains including ecology, natural language processing, chemistry, climate science, and social sciences.
 
-There is worldwide network of Galaxy servers providing open access to virtually all academic users
-consisting of "copies" (instances) of the service. Some major ones are hosted in the [United States](https://usegalaxy.org), [EU](https://usegalaxy.eu), and [Australia](https://usegalaxy.org.au).
+There are many Galaxy servers providing open access to virtually all academic users hosted by various institutions around the world. Some major ones are in the [USA](https://usegalaxy.org), [EU](https://usegalaxy.eu), and [Australia](https://usegalaxy.org.au).
 Besides, [numerous specialized services](https://galaxyproject.org/use/) exist.
 
-Many quickstart and advanced tutorials are available on [Galaxy Training Network](https://training.galaxyproject.org/training-material/topics/introduction/).
+<Callout type="info" title="Tip" icon="💡">
+Metacentrum maintains an independent Galaxy server open to all members of Czech academia (and more). Please [see the details](../graphical/usegalaxy).
+</Callout>
 
-Metacentrum currently maintains 3 independent Galaxy servers: 
+In addition to the usegalaxy.cz Metacentrum also maintains the specialized [RepeatExplorer](../related/galaxy/repeat_explorer) Galaxy instance which is open worldwide thanks to the funding from ELIXIR Europe. And last, for the group at [RECETOX](https://www.recetox.muni.cz/en), we run the Untargeted Mass Spetrometry Analysis Galaxy server -- [UMSA](../related/galaxy/umsa).
 
-1. [usegalaxy.cz](../graphical/usegalaxy) for common usage, it is open for all MetaCentrum users
-
-2. [RepeatExplorerGalaxy](../related/galaxy/repeat_explorer) open worldwide (ELIXIR)
-
-3. [UMSA Galaxy](../related/galaxy/umsa) closed for RECETOX group
-
-
-If you need any help or experience tool errors or have unexpected issues with any of the Galaxy instance above please contact us at regalaxy@rt.cesnet.cz.
+If you need any help or experience tool errors or have unexpected issues with any of the Galaxy instance above please contact us at galaxy@cesnet.cz.


### PR DESCRIPTION
clarify that there is a more detailed page for the main metacentrum galaxy. Simplify the listing of other instances. Drop training for simplicity, it is linked from the other pages.